### PR TITLE
Create CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+seaborn.pydata.org


### PR DESCRIPTION
CNAME required to host the seaborn.pydata.org url
